### PR TITLE
Support `jobs` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,15 @@
 						"debug"
 					],
 					"default": "info"
+				},
+				"steep.jobs": {
+					"markdownDescription": "The value for `--jobs` option.",
+					"type": [
+						"numeric",
+						"null"
+					],
+					"default": null,
+					"minimum": 1
 				}
 			}
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ function startSteep(folder: vscode.WorkspaceFolder) {
 	}
 
 	const loglevel = vscode.workspace.getConfiguration('steep').get("loglevel")
+	const jobs = vscode.workspace.getConfiguration('steep').get("jobs")
 	let serverOptions: ServerOptions
 
 	const binstub = vscode.Uri.file(`${folder.uri.path}/bin/steep`)
@@ -42,14 +43,14 @@ function startSteep(folder: vscode.WorkspaceFolder) {
 		console.log("Detected bin/steep...")
 		serverOptions = {
 			command: "bin/steep",
-			args: ["langserver", `--log-level=${loglevel}`],
+			args: ["langserver", `--log-level=${loglevel}`, jobs ? `--jobs=${jobs}` : ''],
 			options: options
 		}
 	} else {
 		console.log("Using bundle exec to start steep...")
 		serverOptions = {
 			command: "bundle",
-			args: ["exec", "steep", "langserver", `--log-level=${loglevel}`],
+			args: ["exec", "steep", "langserver", `--log-level=${loglevel}`, jobs ? `--jobs=${jobs}` : ''],
 			options: options
 		}
 	}


### PR DESCRIPTION
The `--jobs` option in steep langserver can now be set to any value from vscode.