### PR TITLE
Provide option to change filename of Steepfile and Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It has LSP features including:
 
 * *Restart all* command restarts all Steep processes running for the VSCode. Try this command if something is not working correctly.
 * *Loglevel* option allows to control log level of Steep command. If you set `debug`, many debug prints will be printed and will help you debugging Steep.
+* *Steepfile* option allows to change the `Steepfile` path.
 
 ## How it works
 
@@ -21,7 +22,7 @@ If you have a binstub `bin/steep`, it will be used instead of `bundle exec steep
 
 Requirements are:
 
-1. You have to have `Steepfile` in the root of the folder.
+1. You have to have `Steepfile` in the root of the folder. You can change the filename via `steepfile` option.
 2. You have to use Bundler.
 
 ## Acknowledgments

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It has LSP features including:
 * *Restart all* command restarts all Steep processes running for the VSCode. Try this command if something is not working correctly.
 * *Loglevel* option allows to control log level of Steep command. If you set `debug`, many debug prints will be printed and will help you debugging Steep.
 * *Steepfile* option allows to change the `Steepfile` path.
+* *Gemfile* option allows to change the `Gemfile` path.
 
 ## How it works
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
 					"type": "string",
 					"default": "Steepfile"
 				},
+				"steep.gemfile": {
+					"markdownDescription": "The value for `BUNDLE_GEMFILE` environment variable.",
+					"type": "string",
+					"default": "Gemfile"
+				},
 				"steep.loglevel": {
 					"markdownDescription": "The value for `--log-level` option of Steep Language Server. You can see the output in `output` tab.",
 					"type": "string",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,11 @@
 					"type": "string",
 					"default": ""
 				},
+				"steep.steepfile": {
+					"markdownDescription": "The value for `--steepfile` option of Steep Language Server.",
+					"type": "string",
+					"default": "Steepfile"
+				},
 				"steep.loglevel": {
 					"markdownDescription": "The value for `--log-level` option of Steep Language Server. You can see the output in `output` tab.",
 					"type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,7 @@ async function startSteep(folder: vscode.WorkspaceFolder) {
 		return
 	}
 
+	const gemfileName = vscode.workspace.getConfiguration('steep').get<string>("gemfile") ?? 'Gemfile'
 	const loglevel = vscode.workspace.getConfiguration('steep').get("loglevel")
 	const jobs = vscode.workspace.getConfiguration('steep').get("jobs")
 	const enabled = vscode.workspace.getConfiguration('steep').get('enabled')
@@ -66,6 +67,7 @@ async function startSteep(folder: vscode.WorkspaceFolder) {
 
 	const env = { ...process.env }
 	env.RUBYOPT = `${ rubyopt || "" } -EUTF-8`
+	env.BUNDLE_GEMFILE = gemfileName
 	if (yjit) {
 		env.RUBY_YJIT_ENABLE = "true"
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,8 @@ async function stopSteep(folder: vscode.WorkspaceFolder) {
 // Start Steep if `Steepfile` exists, and register the `LanguageClient` to `_clientSessions`
 //
 async function startSteep(folder: vscode.WorkspaceFolder) {
-	const file = vscode.Uri.file(`${folder.uri.path}/Steepfile`)
+	const steepfileName = vscode.workspace.getConfiguration('steep').get<string>("steepfile") ?? 'Steepfile'
+	const file = vscode.Uri.file(`${folder.uri.path}/${steepfileName}`)
 	if (!existsSync(file.fsPath)) {
 		return
 	}
@@ -78,7 +79,7 @@ async function startSteep(folder: vscode.WorkspaceFolder) {
 
 	const binstub = vscode.Uri.file(`${folder.uri.path}/bin/steep`)
 	const jobsOption = jobs ? [`--jobs=${jobs}`] : []
-	const cmdOptions = ["langserver", `--log-level=${loglevel}`, ...jobsOption]
+	const cmdOptions = ["langserver", `--log-level=${loglevel}`, `--steepfile=${steepfileName}`, ...jobsOption]
 	if (command.length > 0) {
 		const [cmd, ...cmds] = shellParse(command)
 		console.log(`Command is specified:`, [cmd, ...cmds])


### PR DESCRIPTION
Resolves #122

Especially I'd like to specify `Steepfile` path from below 2 reasons.

Many module/class defined within some other files via Ruby's Open Classes feature. They might be used as just a namespace.
Currently steep made diagnostic message for them as `Ruby::MethodDefinitionMissing`. So I execute `steep check` with `--severity-level=warning` option for now. However `steep langserver` does not have the option.

One another reason is simple, I often want to suppress or enable some messages only in editing phase.

Adding `Gemfile` option is not related to above my issue. Just addressing in this PR is for the #122 is covering both. (I have split to 2 commits.)
