### PR TITLE
Add `Hide Diagnostics` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,23 @@
 					"markdownDescription": "Set `RUBY_YJIT_ENABLE` environment variable",
 					"type": "boolean",
 					"default": true
+				},
+				"steep.hideDiagnostics": {
+					"markdownDescription": "Hide diagnostics if its severity is lower than or equal to the option. Empty to disable this feature.",
+					"type": "string",
+					"enum": [
+						"",
+						"Error",
+						"Warning",
+						"Information"
+					],
+					"enumDescriptions": [
+						"Shows all diagnostics",
+						"Hides all diagnostics",
+						"Hides warning and information diagnostics",
+						"Hides information diagnostics"
+					],
+					"default": ""
 				}
 			}
 		}


### PR DESCRIPTION
<img width="825" alt="スクリーンショット 2023-08-27 22 22 03" src="https://github.com/soutaro/steep-vscode/assets/139089/b65fe5a0-11b4-4d33-b965-77b969a5c599">

* `Error` to hide all diagnostics
* `Warning` to hide *warning* and *information* diagnostics
* `Information` to hide *information* diagnostics
* No `Hint` option because they don't appear in *Problems* tab