### PR TITLE
Skip setting `BUNDLE_GEMFILE` if no config is given

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
 				},
 				"steep.gemfile": {
 					"markdownDescription": "The value for `BUNDLE_GEMFILE` environment variable.",
-					"type": "string",
-					"default": "Gemfile"
+					"type": "string"
 				},
 				"steep.loglevel": {
 					"markdownDescription": "The value for `--log-level` option of Steep Language Server. You can see the output in `output` tab.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,7 +32,7 @@ async function startSteep(folder: vscode.WorkspaceFolder) {
 		return
 	}
 
-	const gemfileName = vscode.workspace.getConfiguration('steep').get<string>("gemfile") ?? 'Gemfile'
+	const gemfileName = vscode.workspace.getConfiguration('steep').get<string>("gemfile")
 	const loglevel = vscode.workspace.getConfiguration('steep').get("loglevel")
 	const jobs = vscode.workspace.getConfiguration('steep').get("jobs")
 	const enabled = vscode.workspace.getConfiguration('steep').get('enabled')
@@ -67,7 +67,9 @@ async function startSteep(folder: vscode.WorkspaceFolder) {
 
 	const env = { ...process.env }
 	env.RUBYOPT = `${ rubyopt || "" } -EUTF-8`
-	env.BUNDLE_GEMFILE = gemfileName
+	if (gemfileName) {
+		env.BUNDLE_GEMFILE = gemfileName
+	}
 	if (yjit) {
 		env.RUBY_YJIT_ENABLE = "true"
 	}


### PR DESCRIPTION
Having default `Gemfile` value causes problems when the parent directory has `Gemfile` for the workspace.