### PR TITLE
Add new options: installRbsCollection and rbsCollectionLock

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ It has LSP features including:
 * *Loglevel* option allows to control log level of Steep command. If you set `debug`, many debug prints will be printed and will help you debugging Steep.
 * *Steepfile* option allows to change the `Steepfile` path.
 * *Gemfile* option allows to change the `Gemfile` path.
+* *InstallRbsCollection* option runs `rbs collection install` command on invoking Steep server.
+* *RbsCollectionLock* option allows to change the `rbs_collection.lock` path.
 
 ## How it works
 

--- a/package.json
+++ b/package.json
@@ -95,6 +95,14 @@
 						"Hides information diagnostics"
 					],
 					"default": ""
+				},
+				"steep.installRbsCollection": {
+					"type": "boolean",
+					"default": true
+				},
+				"steep.rbsCollectionLock": {
+					"type": "string",
+					"default": "rbs_collection.lock.yaml"
 				}
 			}
 		}


### PR DESCRIPTION
* installRbsCollection: Run `rbs collection install` before invoking the Steep server
* rbsCollectionLock: The path of rbs_collection.lock.yaml

refs: #379